### PR TITLE
Fix typo in destinations.html

### DIFF
--- a/src/components/artemis/migration-documentation/destinations.html
+++ b/src/components/artemis/migration-documentation/destinations.html
@@ -298,7 +298,7 @@
      <span class="hljs-tag">&lt;<span class="hljs-name">topic</span> <span class="hljs-attr">physicalName</span>=<span class="hljs-string">&quot;my-topic&quot;</span> /&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">destinations</span>&gt;</span>
 </code></pre>
-<p>Things looks a bit different in Artemis. We already explained that queues are <code>anycast</code> addresses and topics are <code>muticast</code> ones. We&apos;re not gonna go deep into the address settings details here and you&apos;re advised to look at the user manual for that. Let&apos;s just see what we need to do in order to replicate ActiveMQ configuration. </p>
+<p>Things looks a bit different in Artemis. We already explained that queues are <code>anycast</code> addresses and topics are <code>multicast</code> ones. We&apos;re not gonna go deep into the address settings details here and you&apos;re advised to look at the user manual for that. Let&apos;s just see what we need to do in order to replicate ActiveMQ configuration. </p>
 <p>Addresses are defined in <code>&lt;addresses&gt;</code> section of the <code>etc/broker.xml</code> configuration file. So the corresponding Artemis configuration for the ActiveMQ example above, looks like this:</p>
 <pre><code class="lang-xml"><span class="hljs-tag">&lt;<span class="hljs-name">addresses</span>&gt;</span>    
     <span class="hljs-tag">&lt;<span class="hljs-name">address</span> <span class="hljs-attr">name</span>=<span class="hljs-string">&quot;my-queue&quot;</span>&gt;</span>


### PR DESCRIPTION
Fix typo in artemis/migration-documentation/destinations.html
"muticast" -> " multicast"